### PR TITLE
[feat] 칼로리 전송 api 연결

### DIFF
--- a/app/src/main/java/com/ddanddan/watch/application/WatchApp.kt
+++ b/app/src/main/java/com/ddanddan/watch/application/WatchApp.kt
@@ -1,12 +1,29 @@
 package com.ddanddan.watch.application
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
+import com.ddanddan.watch.util.WorkerUtils
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
 @HiltAndroidApp
-class WatchApp : Application() {
+class WatchApp : Application(), Configuration.Provider {
+
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
 
     override fun onCreate() {
         super.onCreate()
+
+        WorkerUtils.run {
+            setupDailyMidnightResetWorker(this@WatchApp) // 자정에 칼로리 초기화
+            scheduleSyncCaloriesWorker(this@WatchApp) // 1시간 간격으로 칼로리 보정
+        }
     }
 }

--- a/app/src/main/java/com/ddanddan/watch/data/AuthorizationInterceptor.kt
+++ b/app/src/main/java/com/ddanddan/watch/data/AuthorizationInterceptor.kt
@@ -11,15 +11,15 @@ import okhttp3.Response
 import javax.inject.Inject
 
 class AuthorizationInterceptor @Inject constructor(
-//    private val dataStore: DataStore<Preferences>
+    private val dataStore: DataStore<Preferences>
 ) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
-//        val accessToken = runBlocking {
-//            dataStore.data
-//                .map { preferences -> preferences[PreferencesKeys.ACCESS_TOKEN_KEY] ?: TEST_TOKEN }
-//                .first()
-//        }
+        val accessToken = runBlocking {
+            dataStore.data
+                .map { preferences -> preferences[PreferencesKeys.ACCESS_TOKEN_KEY] ?: TEST_TOKEN }
+                .first()
+        }
 
         val request = chain.request().newBuilder()
             .addHeader("Authorization", "Bearer $TEST_TOKEN")

--- a/app/src/main/java/com/ddanddan/watch/data/WatchTokenAuthenticator.kt
+++ b/app/src/main/java/com/ddanddan/watch/data/WatchTokenAuthenticator.kt
@@ -1,0 +1,50 @@
+package com.ddanddan.watch.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import com.ddanddan.watch.util.PreferencesKeys
+import com.google.android.gms.wearable.MessageClient
+import com.google.android.gms.wearable.Wearable
+import kotlinx.coroutines.runBlocking
+import okhttp3.Authenticator
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import javax.inject.Inject
+
+//class WatchTokenAuthenticator @Inject constructor(
+//    private val context: Context,
+//    private val dataStore: DataStore<Preferences>
+//) : Authenticator {
+//
+//    //401 시 호출
+//    override fun authenticate(route: Route?, response: Response): Request? {
+//        val newToken = runBlocking {
+//            requestTokenRefreshFromPhone()?.also { token ->
+//                // DataStore에 새 토큰 저장
+//                dataStore.edit { preferences ->
+//                    preferences[PreferencesKeys.ACCESS_TOKEN_KEY] = token
+//                }
+//            }
+//        } ?: return null // 새 토큰이 없으면 인증 실패로 처리
+//
+//        // 요청에 새 토큰으로 Authorization 헤더 추가
+//        return response.request.newBuilder()
+//            .header("Authorization", "Bearer $newToken")
+//            .build()
+//    }
+//
+//    private suspend fun requestTokenRefreshFromPhone(): String? {
+//        val messageClient: MessageClient = Wearable.getMessageClient(context)
+//        val node = Wearable.getNodeClient(context).connectedNodes.await().firstOrNull()
+//
+//        node?.let {
+//            val response = messageClient.sendMessage(it.id, "/request_token_refresh", null).await()
+//            return String(response) // 새 토큰 반환
+//        }
+//
+//        return null
+//    }
+//}

--- a/app/src/main/java/com/ddanddan/watch/data/di/DataStoreModule.kt
+++ b/app/src/main/java/com/ddanddan/watch/data/di/DataStoreModule.kt
@@ -12,15 +12,15 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
-//@Module
-//@InstallIn(SingletonComponent::class)
-//object DataStoreModule {
-//
-//    @Provides
-//    @Singleton
-//    fun provideDataStore(@ApplicationContext context: Context): DataStore<Preferences> {
-//        return PreferenceDataStoreFactory.create(
-//            produceFile = { context.dataStoreFile("DdanDdan") }
-//        )
-//    }
-//}
+@Module
+@InstallIn(SingletonComponent::class)
+object DataStoreModule {
+
+    @Provides
+    @Singleton
+    fun provideDataStore(@ApplicationContext context: Context): DataStore<Preferences> {
+        return PreferenceDataStoreFactory.create(
+            produceFile = { context.dataStoreFile("app_data.preferences_pb") }
+        )
+    }
+}

--- a/app/src/main/java/com/ddanddan/watch/data/di/RetrofitModule.kt
+++ b/app/src/main/java/com/ddanddan/watch/data/di/RetrofitModule.kt
@@ -20,8 +20,10 @@ object RetrofitModule {
     @Singleton
     fun provideOkHttpClient(
         authorizationInterceptor: AuthorizationInterceptor,
+//        watchTokenAuthenticator: WatchTokenAuthenticator
     ): OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(authorizationInterceptor)
+//        .authenticator(watchTokenAuthenticator)
         .addInterceptor(HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY))
         .build()
 

--- a/app/src/main/java/com/ddanddan/watch/data/repository/PassiveDataRepositoryImpl.kt
+++ b/app/src/main/java/com/ddanddan/watch/data/repository/PassiveDataRepositoryImpl.kt
@@ -1,48 +1,65 @@
 package com.ddanddan.watch.data.repository
 
-import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.booleanPreferencesKey
-import androidx.datastore.preferences.core.doublePreferencesKey
 import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.preferencesDataStore
 import com.ddanddan.watch.domain.repository.PassiveDataRepository
-import dagger.hilt.android.qualifiers.ApplicationContext
+import com.ddanddan.watch.util.PreferencesKeys
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class PassiveDataRepositoryImpl @Inject constructor(
-    @ApplicationContext private val context: Context
+    private val dataStore: DataStore<Preferences>
 ) : PassiveDataRepository {
 
-    private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "passive_data")
+    // todo - 활용 확인
+    private val _calorieCollectedSignal = MutableSharedFlow<Unit>(replay = 0)
+    override val calorieCollectedSignal: Flow<Unit> get() = _calorieCollectedSignal
 
-    override val passiveDataEnabled: Flow<Boolean> = context.dataStore.data.map { prefs ->
-        prefs[DataStoreKeys.PASSIVE_DATA_ENABLED] ?: false
+    // 패시브 데이터 기능 활성화 여부
+    // todo - 활용 확인
+    override val passiveDataEnabled: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[PreferencesKeys.PASSIVE_DATA_ENABLED] ?: false
     }
 
     override suspend fun setPassiveDataEnabled(enabled: Boolean) {
-        context.dataStore.edit { prefs ->
-            prefs[DataStoreKeys.PASSIVE_DATA_ENABLED] = enabled
+        dataStore.edit { prefs ->
+            prefs[PreferencesKeys.PASSIVE_DATA_ENABLED] = enabled
         }
     }
 
-    override val latestCalories: Flow<Double> = context.dataStore.data.map { prefs ->
-        prefs[DataStoreKeys.LATEST_CALORIES] ?: 0.0
+    // todo - 활용 확인
+    override val latestCalories: Flow<Double> = dataStore.data.map { prefs ->
+        prefs[PreferencesKeys.LATEST_CALORIES] ?: 0.0
     }
 
+    // 새로운 칼로리 데이터를 저장하고 누적 칼로리 값을 업데이트
     override suspend fun storeLatestCalories(calories: Double) {
-        context.dataStore.edit { prefs ->
-            prefs[DataStoreKeys.LATEST_CALORIES] = calories
+        dataStore.edit { prefs ->
+            val currentTotal = prefs[PreferencesKeys.TOTAL_CALORIES] ?: 0.0
+            prefs[PreferencesKeys.LATEST_CALORIES] = calories // 마지막 수집 칼로리 저장
+            prefs[PreferencesKeys.TOTAL_CALORIES] = currentTotal + calories // 누적 칼로리 갱신
         }
+        _calorieCollectedSignal.emit(Unit)
     }
+
+    override val totalCalories: Flow<Double> = dataStore.data.map { prefs ->
+        prefs[PreferencesKeys.TOTAL_CALORIES] ?: 0.0
+    }
+
+    //todo - 로직 검증 필요
+    override suspend fun getCaloriesToSend(): Double? {
+        val totalCalories = totalCalories.first()
+        val caloriesToSend = (totalCalories / CALORIES_FEED_UNIT).toInt() * CALORIES_FEED_UNIT
+
+        return caloriesToSend.takeIf { caloriesToSend > 0 }
+    }
+
 
     companion object {
-        object DataStoreKeys {
-            val PASSIVE_DATA_ENABLED = booleanPreferencesKey("passive_data_enabled")
-            val LATEST_CALORIES = doublePreferencesKey("latest_calories")
-        }
+        const val CALORIES_FEED_UNIT = 100.0 // 100 kcal 당 먹이 1개
     }
 }

--- a/app/src/main/java/com/ddanddan/watch/domain/repository/PassiveDataRepository.kt
+++ b/app/src/main/java/com/ddanddan/watch/domain/repository/PassiveDataRepository.kt
@@ -8,4 +8,9 @@ interface PassiveDataRepository {
 
     val latestCalories: Flow<Double>
     suspend fun storeLatestCalories(calories: Double)
+
+    val totalCalories: Flow<Double>
+    suspend fun getCaloriesToSend(): Double?
+
+    val calorieCollectedSignal: Flow<Unit>
 }

--- a/app/src/main/java/com/ddanddan/watch/presentation/MidnightWorker.kt
+++ b/app/src/main/java/com/ddanddan/watch/presentation/MidnightWorker.kt
@@ -1,0 +1,34 @@
+package com.ddanddan.watch.presentation
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.ddanddan.watch.util.PreferencesKeys
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import timber.log.Timber
+
+@HiltWorker
+class MidnightWorker @AssistedInject constructor(
+    @Assisted private val context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val dataStore: DataStore<Preferences>
+) : CoroutineWorker(context, workerParams) {
+
+    override suspend fun doWork(): Result {
+        return try {
+            dataStore.edit { prefs ->
+                prefs[PreferencesKeys.TOTAL_CALORIES] = 0.0 // 누적 칼로리 초기화
+            }
+            Timber.d("Calories reset to 0 at midnight.")
+            Result.success()
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to reset calories at midnight.")
+            Result.retry()
+        }
+    }
+}

--- a/app/src/main/java/com/ddanddan/watch/presentation/PassiveDataApp.kt
+++ b/app/src/main/java/com/ddanddan/watch/presentation/PassiveDataApp.kt
@@ -32,7 +32,6 @@ fun PassiveDataApp(viewModel: PassiveDataViewModel = hiltViewModel()) {
     }
 }
 
-/** UI 렌더링 **/
 @Composable
 fun RenderUI(
     uiState: UiState,
@@ -42,13 +41,15 @@ fun RenderUI(
     goalCalories: Double
 ) {
     when (uiState) {
-        UiState.Startup -> LoadingScreen()
+        UiState.Loading -> LoadingScreen()
         UiState.Supported -> RenderSupportedUI(user, mainPet, calories, goalCalories)
         UiState.NotSupported -> NotSupportedScreen()
+        is UiState.Error -> {
+            //todo - 예외 처리
+        }
     }
 }
 
-/** Supported 상태 UI 렌더링 **/
 @Composable
 fun RenderSupportedUI(
     user: User?,
@@ -68,12 +69,10 @@ fun RenderSupportedUI(
     }
 }
 
-/** 목표 칼로리 계산 **/
 private fun calculateGoalCalories(user: User?): Double {
     return user?.purposeCalorie?.toDouble() ?: 1000.0
 }
 
-/** 로딩 화면 **/
 @Composable
 fun LoadingScreen() {
     Box(

--- a/app/src/main/java/com/ddanddan/watch/presentation/PassiveDataViewModel.kt
+++ b/app/src/main/java/com/ddanddan/watch/presentation/PassiveDataViewModel.kt
@@ -2,13 +2,16 @@ package com.ddanddan.watch.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import com.ddanddan.watch.data.request.RequestDailyCalorie
 import com.ddanddan.watch.domain.model.MainPet
 import com.ddanddan.watch.domain.model.User
 import com.ddanddan.watch.domain.repository.DdanDdanRepository
 import com.ddanddan.watch.domain.repository.HealthServicesRepository
 import com.ddanddan.watch.domain.repository.PassiveDataRepository
+import com.ddanddan.watch.util.WorkerUtils.SYNC_CALORIES_WORKER
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -17,7 +20,6 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.zip
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -26,10 +28,11 @@ import javax.inject.Inject
 class PassiveDataViewModel @Inject constructor(
     private val healthServicesRepository: HealthServicesRepository,
     private val passiveDataRepository: PassiveDataRepository,
-    private val ddanDdanRepository: DdanDdanRepository
+    private val ddanDdanRepository: DdanDdanRepository,
+    private val workManager: WorkManager
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow<UiState>(UiState.Startup)
+    private val _uiState = MutableStateFlow<UiState>(UiState.Loading)
     val uiState: StateFlow<UiState> = _uiState.asStateFlow()
 
     private val _userState = MutableStateFlow<User?>(null)
@@ -42,33 +45,57 @@ class PassiveDataViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), Double.NaN)
 
     init {
+        // 워치 디바이스가 칼로리 수집을 지원하는지 확인
         viewModelScope.launch {
             checkCalorieSupportAndRegister()
         }
 
+        // 목표 칼로리, 메인펫 화면 갱신
         viewModelScope.launch {
             loadUserAndPetData()
-                .onStart { _uiState.value = UiState.Startup } // 시작 상태
-                .catch { e -> // 예외 처리
-                    Timber.e("Failed to load user or pet data: ${e.message}")
-                    _uiState.value = UiState.NotSupported
-                }
-                .collect { result -> // 성공 시 데이터 반영
-                    _userState.value = result.first
-                    _mainPetState.value = result.second
-                    _uiState.value = UiState.Supported
-                }
         }
+
+        // 칼로리가 수집될 때마다 100 단위로 나누어 떨어지는지 확인 후 필요 시 서버로 전송
+        viewModelScope.launch {
+            passiveDataRepository.calorieCollectedSignal.collect {
+                uploadCaloriesToServer()
+            }
+        }
+
+        // 칼로리 동기화 성공 시 화면 최신화
+        observeSyncCaloriesWork()
     }
 
-    private fun loadUserAndPetData(): Flow<Pair<User, MainPet>> {
-        val userFlow = flow { emit(ddanDdanRepository.getUser()) }
-        val mainPetFlow = flow { emit(ddanDdanRepository.getMainPet()) }
-
-        return userFlow.zip(mainPetFlow) { user, mainPet ->
-            user to mainPet
+    private suspend fun loadUserAndPetData() {
+        flow {
+            val user = ddanDdanRepository.getUser()
+            val mainPet = ddanDdanRepository.getMainPet()
+            emit(user to mainPet)
         }
+            .onStart { _uiState.value = UiState.Loading }
+            .catch { e ->
+                Timber.e("Failed to load user or pet data: ${e.message}")
+                _uiState.value = UiState.NotSupported
+            }
+            .collect { (user, mainPet) ->
+                _userState.value = user
+                _mainPetState.value = mainPet
+                _uiState.value = UiState.Supported
+            }
     }
+
+    private fun observeSyncCaloriesWork() {
+        workManager.getWorkInfosForUniqueWorkLiveData(SYNC_CALORIES_WORKER)
+            .observeForever { workInfos ->
+                val workInfo = workInfos.firstOrNull()
+                if (workInfo?.state == WorkInfo.State.SUCCEEDED) {
+                    viewModelScope.launch {
+                        loadUserAndPetData()
+                    }
+                }
+            }
+    }
+
 
     private suspend fun checkCalorieSupportAndRegister() {
         val isCalorieSupported = healthServicesRepository.hasCaloriesCapability()
@@ -78,11 +105,32 @@ class PassiveDataViewModel @Inject constructor(
             _uiState.value = UiState.NotSupported
         }
     }
-}
 
+    private fun uploadCaloriesToServer() {
+        viewModelScope.launch {
+            passiveDataRepository.getCaloriesToSend()
+                ?.let { caloriesToSend ->
+                    flow {
+                        val requestBody = RequestDailyCalorie(caloriesToSend.toInt())
+                        val response = ddanDdanRepository.patchDailyCalorie(requestBody)
+                        emit(response)
+                    }
+                        .catch { e ->
+                            Timber.e(e, "Error uploading calories")
+                            _uiState.value = UiState.Error(e.message.toString())
+                        }
+                        .collect {
+                            _uiState.value = UiState.Supported
+                        }
+                }
+        }
+    }
+}
 
 sealed class UiState {
-    data object Startup : UiState()
+    data object Loading : UiState()
     data object NotSupported : UiState()
     data object Supported : UiState()
+    data class Error(val message: String) : UiState()
 }
+

--- a/app/src/main/java/com/ddanddan/watch/presentation/SyncCalorieWorker.kt
+++ b/app/src/main/java/com/ddanddan/watch/presentation/SyncCalorieWorker.kt
@@ -1,0 +1,46 @@
+package com.ddanddan.watch.presentation
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.ddanddan.watch.data.repository.PassiveDataRepositoryImpl.Companion.CALORIES_FEED_UNIT
+import com.ddanddan.watch.data.request.RequestDailyCalorie
+import com.ddanddan.watch.domain.repository.DdanDdanRepository
+import com.ddanddan.watch.domain.repository.PassiveDataRepository
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.flow.first
+import timber.log.Timber
+
+@HiltWorker
+class SyncCaloriesWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val passiveDataRepository: PassiveDataRepository,
+    private val ddanDdanRepository: DdanDdanRepository
+) : CoroutineWorker(context, workerParams) {
+
+    /** 로컬과 서버 칼로리 값 동기화
+     * ex) 유저 정보를 조회했을 때 먹이가 3개면 서버로 전송된 누적 칼로리는 300이어야 함
+     * 만약 로컬엔 400이 있다면 100만큼 누락이 됐다는 것이니 보정을 해주는 것
+     * **/
+    override suspend fun doWork(): Result {
+        return runCatching {
+            val totalCalories = passiveDataRepository.totalCalories.first()
+            val serverFeedCount = ddanDdanRepository.getUser().foodQuantity
+            val serverCalories = serverFeedCount * CALORIES_FEED_UNIT
+
+            if (totalCalories > serverCalories) { // 로컬 누적 칼로리가 서버보다 클 경우, 부족한 만큼 서버에 전송
+                val caloriesToSend = (totalCalories / CALORIES_FEED_UNIT).toInt() * CALORIES_FEED_UNIT // 100 단위로 보낼 칼로리 계산
+                val requestBody = RequestDailyCalorie(caloriesToSend.toInt())
+                ddanDdanRepository.patchDailyCalorie(requestBody)
+            }
+
+            Result.success()
+        }.getOrElse { e ->
+            Timber.e(e, "Error synchronizing calories in SyncCaloriesWorker")
+            Result.retry() // 실패 시 재시도 요청
+        }
+    }
+}

--- a/app/src/main/java/com/ddanddan/watch/util/PreferencesKeys.kt
+++ b/app/src/main/java/com/ddanddan/watch/util/PreferencesKeys.kt
@@ -1,7 +1,12 @@
 package com.ddanddan.watch.util
 
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.doublePreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 
 object PreferencesKeys {
+    val PASSIVE_DATA_ENABLED = booleanPreferencesKey("passive_data_enabled")
+    val LATEST_CALORIES = doublePreferencesKey("latest_calories")
+    val TOTAL_CALORIES = doublePreferencesKey("total_calories")
     val ACCESS_TOKEN_KEY = stringPreferencesKey("access_token")
 }

--- a/app/src/main/java/com/ddanddan/watch/util/WorkerUtils.kt
+++ b/app/src/main/java/com/ddanddan/watch/util/WorkerUtils.kt
@@ -1,0 +1,70 @@
+package com.ddanddan.watch.util
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import com.ddanddan.watch.presentation.MidnightWorker
+import com.ddanddan.watch.presentation.SyncCaloriesWorker
+import java.util.Calendar
+import java.util.concurrent.TimeUnit
+
+object WorkerUtils {
+
+    // 다음 자정까지 남은 시간을 계산하는 함수
+    private fun getMillisUntilNextMidnight(): Long {
+        val now = Calendar.getInstance()
+        val nextMidnight = Calendar.getInstance().apply {
+            set(Calendar.HOUR_OF_DAY, 0)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+            add(Calendar.DAY_OF_YEAR, 1)
+        }
+        return nextMidnight.timeInMillis - now.timeInMillis
+    }
+
+    // 매일 자정에 실행되도록 설정하는 WorkManager 설정 함수
+    fun setupDailyMidnightResetWorker(context: Context) {
+        val millisUntilNextMidnight = getMillisUntilNextMidnight() // 자정까지의 남은 시간 계산
+
+        val midnightResetRequest = PeriodicWorkRequestBuilder<MidnightWorker>(1, TimeUnit.DAYS)
+            .setInitialDelay(millisUntilNextMidnight, TimeUnit.MILLISECONDS) // 첫 실행을 자정에 맞춤
+            .setConstraints(
+                Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.NOT_REQUIRED) // 네트워크 불필요
+                    .setRequiresBatteryNotLow(false) // 배터리가 낮은 경우에도 실행
+                    .build()
+            )
+            .build()
+
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            MIDNIGHT_RESET_WORKER,
+            ExistingPeriodicWorkPolicy.UPDATE, // 기존 작업 유지, 새로운 설정은 다음 주기에 적용
+            midnightResetRequest
+        )
+    }
+
+    fun scheduleSyncCaloriesWorker(context: Context) {
+        val workRequest = PeriodicWorkRequestBuilder<SyncCaloriesWorker>(1, TimeUnit.HOURS)
+            .setConstraints(
+                Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED) // 네트워크 연결 필요
+                    .setRequiresBatteryNotLow(false) // 배터리가 낮은 경우에도 실행
+                    .build()
+            )
+            .build()
+
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            SYNC_CALORIES_WORKER,
+            ExistingPeriodicWorkPolicy.UPDATE, // 기존 작업 유지, 새로운 설정은 다음 주기에 적용
+            workRequest
+        )
+    }
+
+    const val SYNC_CALORIES_WORKER = "SyncCaloriesWorker"
+    const val MIDNIGHT_RESET_WORKER = "MidnightResetWorker"
+
+}

--- a/app/src/main/java/com/ddanddan/watch/util/ext/ContextExt.kt
+++ b/app/src/main/java/com/ddanddan/watch/util/ext/ContextExt.kt
@@ -1,0 +1,8 @@
+package com.ddanddan.watch.util.ext
+
+import android.content.Context
+import android.widget.Toast
+
+fun Context.showToast(message: String, duration: Int = Toast.LENGTH_SHORT) {
+    Toast.makeText(this, message, duration).show()
+}


### PR DESCRIPTION
- close #16

### 작업
- 자정 시 칼로리 초기화 워커 추가
- 1시간 간격으로 칼로리 보정 워커 추가
- 칼로리 동기화 시 화면 갱신
- 수집한 칼로리 모니터링하다가 100 단위가 됐을 때 서버로 전송 로직 추가

### 참고
잔여 작업
- 폰에서 워치로 토큰 전송 로직 추가
- 워치에서 폰으로 토큰 갱신 요청 보내기
- 권한 요청 로직 개선
- 테스트
- 파일 정리
  - 파일 분리
  - 폴더링
  - 불필요한 주석 및 코드 정리